### PR TITLE
Fix frontend website databarbosa.com

### DIFF
--- a/react-portfolio/src/components/About.js
+++ b/react-portfolio/src/components/About.js
@@ -52,7 +52,7 @@ const About = () => {
             About Me
           </motion.h2>
           <motion.p className="section-subtitle" variants={itemVariants}>
-            AI Solution Architect at Harvard | Founder of Kojo Analytics
+            AI Solutions Architect at Harvard | Founder of Kojo Analytics
           </motion.p>
         </motion.div>
         
@@ -65,7 +65,7 @@ const About = () => {
           <div className="about-grid">
             <motion.div className="about-text" variants={itemVariants}>
               <p className="lead">
-                I am an <strong>AI Solution Architect</strong> at Harvard, responsible for understanding internal processes, identifying inefficiencies, proposing solutions, prototyping to collect stakeholder feedback, and implementing with stakeholder buy-in and user acceptance.
+                I am an <strong>AI Solutions Architect</strong> at Harvard, responsible for understanding internal processes, identifying inefficiencies, proposing solutions, prototyping to collect stakeholder feedback, and implementing with stakeholder buy-in and user acceptance.
               </p>
               <p>
                 I’m also the founder of <strong>Kojo Analytics</strong> (<a href="https://kojoanalytics.com" target="_blank" rel="noopener noreferrer">kojoanalytics.com</a>), where I deliver AI-powered data solutions and consulting, from discovery and requirements through prototyping, validation, and implementation.

--- a/react-portfolio/src/components/Footer.js
+++ b/react-portfolio/src/components/Footer.js
@@ -43,7 +43,7 @@ const Footer = () => {
           >
             <h3 className="footer-title">Carlos Barbosa</h3>
             <p className="footer-description">
-              AI Solution Architect at Harvard and founder of Kojo Analytics. I analyze processes, design solutions, prototype for feedback, and implement with stakeholder buy-in.
+              AI Solutions Architect at Harvard and founder of Kojo Analytics. I analyze processes, design solutions, prototype for feedback, and implement with stakeholder buy-in.
             </p>
             <div className="social-links">
               {socialLinks.map((link, index) => (

--- a/react-portfolio/src/components/Hero.js
+++ b/react-portfolio/src/components/Hero.js
@@ -29,7 +29,7 @@ const Hero = () => {
     if (typedRef.current) {
       const typed = new Typed(typedRef.current, {
         strings: [
-          'AI Solution Architect at Harvard',
+          'AI Solutions Architect at Harvard',
           'Founder of Kojo Analytics',
           'Process Improvement & Prototyping',
           'Stakeholder Engagement & Delivery'
@@ -72,7 +72,7 @@ const Hero = () => {
           </motion.div>
           
           <motion.p className="hero-description" variants={itemVariants}>
-            AI Solution Architect at Harvard. I analyze processes, identify inefficiencies, design solutions, prototype for feedback, and implement with stakeholder buy-in. Founder of Kojo Analytics (kojoanalytics.com).
+            AI Solutions Architect at Harvard. I analyze processes, identify inefficiencies, design solutions, prototype for feedback, and implement with stakeholder buy-in. Founder of Kojo Analytics (kojoanalytics.com).
           </motion.p>
           
           <motion.blockquote className="hero-quote" variants={itemVariants}>


### PR DESCRIPTION
…itect'

Updated the position title across all components to correctly reflect the plural form 'AI Solutions Architect' instead of 'AI Solution Architect'.

Changes made in:
- Hero.js: Typed animation text and hero description
- About.js: Section subtitle and lead paragraph
- Footer.js: Footer description

This ensures consistency across the entire portfolio website.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes the role to "AI Solutions Architect" across `Hero.js`, `About.js`, and `Footer.js` (typed strings, subtitles, and descriptions).
> 
> - **Frontend copy updates**:
>   - `react-portfolio/src/components/Hero.js`: Update typed strings and hero description to "AI Solutions Architect".
>   - `react-portfolio/src/components/About.js`: Update section subtitle and lead paragraph.
>   - `react-portfolio/src/components/Footer.js`: Update footer description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46cb1d85bc1a19f8548fc2adbc9dbaea00d46368. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->