### PR TITLE
Add GA4 section-view engagement tracking (single-page portfolio)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,11 @@ import About from './components/About';
 import Projects from './components/Projects';
 import Certifications from './components/Certifications';
 import Contact from './components/Contact';
+import useSectionTracking from './hooks/useSectionTracking';
 
 function App() {
+  useSectionTracking();
+
   return (
     <div className="min-h-screen bg-surface-deep text-neutral-700">
       <Navbar />

--- a/src/hooks/useSectionTracking.js
+++ b/src/hooks/useSectionTracking.js
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+// The portfolio is a single page, so GA4's standard page_view tracking only
+// ever records "/". This hook fires a `section_view` event the first time each
+// major section scrolls into view, giving visibility into how far visitors
+// actually get (and whether the headline "100% bounce" reflects real instant
+// exits or just the lack of in-page engagement signals).
+const SECTIONS = ['about', 'projects', 'credentials', 'contact'];
+
+export default function useSectionTracking() {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+      return undefined;
+    }
+    const seen = new Set();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && !seen.has(entry.target.id)) {
+            seen.add(entry.target.id);
+            window.gtag('event', 'section_view', {
+              section_name: entry.target.id,
+            });
+          }
+        });
+      },
+      { threshold: 0.4 },
+    );
+
+    SECTIONS.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+}


### PR DESCRIPTION
## Why
GA4 analysis (property `462450193`, host `databarbosa.com`, 28 days to 2026-06-25) showed:
- Homepage `/`: **engagementRate 0**, **avg session 0.08s**, **bounce 100%**
- Only `/` is ever recorded

The site is a **single page** (no routes), so standard `page_view` tracking can't show whether visitors actually scroll or leave instantly — the headline numbers are ambiguous.

## What
Adds `useSectionTracking` (an IntersectionObserver hook) that fires a GA4 `section_view` event the first time each major section (`about`, `projects`, `credentials`, `contact`) scrolls into view.

## Result
You'll be able to see in GA4 (Events → `section_view`, param `section_name`) how far visitors get — distinguishing real instant-bounces from people who scroll but don't trigger engagement signals.

- No layout/DOM changes (observes existing section ids)
- No-op if `gtag` isn't present
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)