### PR TITLE
Add og:image + Twitter card for social sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
     <meta property="og:title" content="Carlos Barbosa | AI Solutions Architect" />
     <meta property="og:description" content="AI Solutions Architect at Harvard Maintenance. Founder of Kojo Analytics." />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://databarbosa.com/" />
+    <meta property="og:image" content="https://databarbosa.com/assets/images/profile.jpg" />
+    <meta property="og:image:alt" content="Carlos Barbosa" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Carlos Barbosa | AI Solutions Architect" />
+    <meta name="twitter:description" content="AI Solutions Architect at Harvard Maintenance. Founder of Kojo Analytics." />
+    <meta name="twitter:image" content="https://databarbosa.com/assets/images/profile.jpg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Why
GA4 (host `databarbosa.com`, 28 days to 2026-06-25): acquisition is almost entirely **Direct + Instagram/social** (`ig / social`), with no organic search. Shared links have **no preview image**, so they look bare on Instagram/social.

## What
Adds to `index.html` (the existing `og:title/description/type` stay):
- `og:url`
- `og:image` + `og:image:alt` (reuses existing `/assets/images/profile.jpg`)
- Twitter `summary_large_image` card tags

## Result
Links shared to Instagram/social render a rich card with image + title, which should lift click-through from your main acquisition channel. Pure `<head>` metadata — no runtime/layout impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)